### PR TITLE
[TH2-4082] fix NPE

### DIFF
--- a/src/main/java/com/exactpro/th2/validator/PinsValidator.java
+++ b/src/main/java/com/exactpro/th2/validator/PinsValidator.java
@@ -66,7 +66,7 @@ class PinsValidator {
             List<Map<String, Object>> arraySection, String boxName) {
 
         if (arraySection == null) {
-            return null;
+            return Collections.emptyList();
         }
 
         List<Map<String, Object>> uniquePins = new ArrayList<>();

--- a/src/main/java/com/exactpro/th2/validator/SchemaContext.java
+++ b/src/main/java/com/exactpro/th2/validator/SchemaContext.java
@@ -17,9 +17,6 @@
 package com.exactpro.th2.validator;
 
 import com.exactpro.th2.infrarepo.repo.RepositoryResource;
-import com.exactpro.th2.validator.enums.ValidationResult;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -60,17 +57,11 @@ public class SchemaContext {
     }
 
     private RepositoryResource getDictionary(String dictionaryName) {
-        return dictionaries.get(dictionaryName);
+        return dictionaries != null ? dictionaries.get(dictionaryName) : null;
     }
 
     public SchemaValidationContext getSchemaValidationContext() {
         return schemaValidationContext;
     }
 
-    private static class ResourcesList {
-
-        private final ValidationResult result = ValidationResult.valid();
-
-        private final ArrayList<RepositoryResource> linkedResources = new ArrayList<>();
-    }
 }

--- a/src/test/resources/linkstest/rpt-data-provider.yml
+++ b/src/test/resources/linkstest/rpt-data-provider.yml
@@ -43,3 +43,9 @@ spec:
             - raw
             - publish
             - demo-csv
+    grpc:
+      server:
+        - name: someServer
+          serviceClasses:
+            - someClasses
+      #client:


### PR DESCRIPTION
NPE occurred in `arrangeBoxLinks` because the private `uniquePinsInArraySection` in PinsValidator overwrote `null` value to empty sections inside YAML. Also make `dictionaryExists` null-safe, even though `dictionaries` map is not expected to be null in any case. 